### PR TITLE
Made date format configurable using parameter

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,3 @@
+[Params]
+  dateformat = "01-02-2006"
+  dateformatpretty = "January 02 2006"

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -14,13 +14,13 @@
         {{ if eq .Type "posts" }}
         <li>
           {{ if .Draft }}
-          DRAFT: 
+          DRAFT:
           {{ end }}
           <a class="post-list" href="{{ .Permalink }}">{{ $page.Title }}</a>
 
           <p class="footnote">
-          <time datetime="{{ $page.Date.Format "01-02-2006" }}">
-            {{ $page.Date.Format "01-02-2006" }}
+          <time datetime="{{ $page.Date.Format .Site.Params.dateformat }}">
+            {{ $page.Date.Format .Site.Params.dateformat }}
           </time>
           </p>
         </li>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -8,7 +8,7 @@
 
       <div class="post-title">
         <p class="footnote">
-        <time class="">{{ .Date.Format "01-02-2006" }}</time>
+        <time class="">{{ .Date.Format .Site.Params.dateformatpretty }}</time>
         {{ $baseurl := .Site.BaseURL }}
         {{ if or .Params.tags .Params.categories .Params.series }}
         |

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -14,15 +14,15 @@
 		{{ if eq .Type "posts" }}
 		<li>
 		  {{ if .Draft }}
-		  DRAFT: 
+		  DRAFT:
 		  {{ end }}
 		  <a class="post-list" href="{{ .Permalink }}">{{ $page.Title }}</a>
 
 		  <p class="footnote">
-			<time datetime="{{ $page.Date.Format "01-02-2006T15:04:05Z07:00" }}">{{ $page.Date.Format "01-02-2006" }}</time>
+			<time datetime="{{ $page.Date.Format "01-02-2006T15:04:05Z07:00" }}">{{ $page.Date.Format .Site.Params.dateformat }}</time>
 
 			{{ if or $page.Params.tags $page.Params.categories $page.Params.series }}
-		  |	
+		  |
 			{{ end }}
 
 			{{ with $page.Params.tags }}

--- a/layouts/single.html
+++ b/layouts/single.html
@@ -7,7 +7,7 @@
     <div class="post">
       <div class="post-title">
         <p class="footnote">
-        <time class="">{{ .Date.Format "01-02-2006" }}</time>
+        <time class="">{{ .Date.Format .Site.Params.dateformatpretty }}</time>
         {{ $baseurl := .Site.BaseURL }}
         {{ if or .Params.tags .Params.categories .Params.series }}
         |


### PR DESCRIPTION
Closes #12 

As discussed in issue #12 this makes the date format configurable via a param. I don't see a way of how a template could provide a default value for a param, from what I can tell the `config.toml` in a theme is just to provide an example.

Also, sorry about the trimmed whitespaces at the end of the line, my editor does that and I didn't realize until I put this up.  

@aos what do you think? 