### PR TITLE
Enhancement: Custom date format

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ copyright = "(c) 2008 - 2014"
   # Enables the topmenu, which pulls from categories
   topmenu = "categories"
 
+  # Enables custom date format (optional, the default is MM-DD-YYYY)
+  # For reference to date and time templating, see:
+  # https://gohugo.io/functions/format/#hugo-date-and-time-templating-reference
+  dateformatpretty = "2006-01-02"
+
 # Builds a list page for each category given
 [taxonomies]
   tag = "tags"

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -20,7 +20,11 @@
 
           <p class="footnote">
             <time datetime="{{ $page.Date }}">
-              {{ $page.Date.Format "01-02-2006" }}
+              {{ if .Site.Params.dateformatpretty }}
+                {{ $page.Date.Format .Site.Params.dateformatpretty }}
+              {{ else }}
+                {{ $page.Date.Format "01-02-2006" }}
+              {{ end }}
             </time>
           </p>
         </li>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -8,7 +8,13 @@
 
       <div class="post-title">
         <p class="footnote">
-        <time class="">{{ .Date.Format "01-02-2006" }}</time>
+          <time datetime="{{ .Date }}">
+            {{ if .Site.Params.dateformatpretty }}
+              {{ .Date.Format .Site.Params.dateformatpretty }}
+            {{ else }}
+              {{ .Date.Format "01-02-2006" }}
+            {{ end }}
+          </time>
         {{ $baseurl := .Site.BaseURL }}
         {{ if or .Params.tags .Params.categories .Params.series }}
         |

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -18,32 +18,38 @@
 		  {{ end }}
 		  <a class="post-list" href="{{ .Permalink }}">{{ $page.Title }}</a>
 
-		  <p class="footnote">
-			<time datetime="{{ $page.Date.Format "01-02-2006T15:04:05Z07:00" }}">{{ $page.Date.Format "01-02-2006" }}</time>
+      <p class="footnote">
+        <time datetime="{{ $page.Date }}">
+          {{ if .Site.Params.dateformatpretty }}
+            {{ $page.Date.Format .Site.Params.dateformatpretty }}
+          {{ else }}
+            {{ $page.Date.Format "01-02-2006" }}
+          {{ end }}
+        </time>
 
-			{{ if or $page.Params.tags $page.Params.categories $page.Params.series }}
-		  |	
-			{{ end }}
+        {{ if or $page.Params.tags $page.Params.categories $page.Params.series }}
+        |
+        {{ end }}
 
-			{{ with $page.Params.tags }}
-			tags: [ {{ range $page.Params.tags}}<a href="{{ $baseurl }}tags/{{ . | urlize }}">{{ . }}</a> {{ end }}]
-			{{ end }}
+        {{ with $page.Params.tags }}
+        tags: [ {{ range $page.Params.tags}}<a href="{{ $baseurl }}tags/{{ . | urlize }}">{{ . }}</a> {{ end }}]
+        {{ end }}
 
-			{{ with $page.Params.categories }}
-			categories: [ {{ range $page.Params.categories }}<a href="{{ $baseurl }}categories/{{ . | urlize }}">{{ . }}</a> {{ end }}]
-			{{ end }}
+        {{ with $page.Params.categories }}
+        categories: [ {{ range $page.Params.categories }}<a href="{{ $baseurl }}categories/{{ . | urlize }}">{{ . }}</a> {{ end }}]
+        {{ end }}
 
-			{{ with $page.Params.series }}
-			series: [ {{ range $page.Params.series }}<a href="{{ $baseurl }}series/{{ . | urlize }}">{{ . }}</a> {{ end }}]
-			{{ end }}
+        {{ with $page.Params.series }}
+        series: [ {{ range $page.Params.series }}<a href="{{ $baseurl }}series/{{ . | urlize }}">{{ . }}</a> {{ end }}]
+        {{ end }}
 
-		  </p>
-		</li>
-		{{ end }}
-		{{ end }}
-	  </ul>
-	</div>
-	</div>
+      </p>
+    </li>
+    {{ end }}
+    {{ end }}
+    </ul>
+  </div>
+  </div>
   <div class="pure-u-1-24 pure-u-md-5-24"></div>
 </div>
 

--- a/layouts/partials/css/custom.css
+++ b/layouts/partials/css/custom.css
@@ -87,7 +87,7 @@ body {
 .footnote {
 	font-family: verdana,arial,helvetica,sans-serif;
 	color:#888;
-	font-size:x-small;
+	font-size:0.75em;
 	margin-bottom:0;
 }
 

--- a/layouts/single.html
+++ b/layouts/single.html
@@ -7,7 +7,13 @@
     <div class="post">
       <div class="post-title">
         <p class="footnote">
-        <time class="">{{ .Date.Format "01-02-2006" }}</time>
+        <time datetime="{{ .Date }}">
+          {{ if .Site.Params.dateformatpretty }}
+            {{ .Date.Format .Site.Params.dateformatpretty }}
+          {{ else }}
+            {{ .Date.Format "01-02-2006" }}
+          {{ end }}
+        </time>
         {{ $baseurl := .Site.BaseURL }}
         {{ if or .Params.tags .Params.categories .Params.series }}
         |

--- a/theme.toml
+++ b/theme.toml
@@ -5,7 +5,7 @@ licenselink = "http://opensource.org/licenses/MIT"
 homepage = "https://github.com/aos/temple"
 tags = ["blog", "personal", "responsive", "minimal"]
 features = ["highlightjs", "responsive", "black-and-white"]
-min_version=0.13
+min_version = 0.13
 
 [author]
     name = "Aos Dabbagh"


### PR DESCRIPTION
Closes #12 

This PR will enable custom date formats. They can be passed in as configuration variables in your `config` file under:
```
[params]
  dateformatpretty = "January 06 2009"
```

Refer to the README for more details. I've also increased the font-size for the date-time tag to be more readable.

![image](https://user-images.githubusercontent.com/25783780/48448099-eb4cdc80-e76b-11e8-92b9-fd53cb726780.png)