### PR TITLE
Fix missing space into the square brackets of categories display

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -24,7 +24,7 @@
         {{ end }}
 
         {{ if isset .Params "categories" }}
-        categories: [{{ range .Params.categories }}<a href="{{ $baseurl }}categories/{{ . | urlize }}">{{ . }}</a> {{ end }}]
+        categories: [ {{ range .Params.categories }}<a href="{{ $baseurl }}categories/{{ . | urlize }}">{{ . }}</a> {{ end }}]
         {{ end }}
 
         {{ if isset .Params "series" }}


### PR DESCRIPTION
Hey there - just a single space character :) 

I just noticed, that the display of the categories is missing a space when viewing a single post. (list view is correct)

* Correct:
![list-view](https://user-images.githubusercontent.com/1112380/49691237-f3ffbb00-fb3d-11e8-83cc-b08752a09166.png)

* Now fixed:
![single-view](https://user-images.githubusercontent.com/1112380/49691238-f3ffbb00-fb3d-11e8-9e82-202d32ca45d2.png)

