### PR TITLE
Do not display RSS Link in the footer, when none is available

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -34,7 +34,9 @@
 
         </ul>
         <a href="#" class="pure-menu-link pull-right" id="gototop-btn">↑↑</a>
+        {{ if .RSSLink }}
         <a href="{{ .RSSLink }}" class="pure-menu-link pull-right">RSS</a>
+        {{ end }}
       </div>
       {{ if .Site.Copyright }}
       <p id="foot-copyright">{{ .Site.Copyright | safeHTML }}</p>


### PR DESCRIPTION
Hey there - another thing I noticed.

Sometimes the `{{ .RSSLink }}` does not return anything, so the RSS-Link in the Website Footer (e.g. when viewing a single page) was not valid.

The HTML created looked like this:
```
    <a href="" class="pure-menu-link pull-right">RSS</a>
``` 
So it was pointing to itself.

I decided to completely disable the display, like it is done in `partials/header.html`
