### PR TITLE
Increase text contrast to AAA accessibility level

### DIFF
--- a/layouts/partials/css/custom.css
+++ b/layouts/partials/css/custom.css
@@ -9,6 +9,10 @@ body {
 	color: #484848;
 }
 
+a {
+	text-decoration: none;
+}
+
 .nav-menu {
   margin-top: 5px;
   padding-bottom: 5px;
@@ -75,7 +79,7 @@ body {
 	margin-bottom: 1em;
 }
 
-.posts li a {
+.posts li > a {
 	color:#369;
 	text-decoration:none;
 }
@@ -92,7 +96,7 @@ body {
 }
 
 .footnote a {
-	color: #888 !important
+	color: #888;
 }
 
 .footnote a:hover{

--- a/layouts/partials/css/custom.css
+++ b/layouts/partials/css/custom.css
@@ -90,13 +90,13 @@ a {
 
 .footnote {
 	font-family: verdana,arial,helvetica,sans-serif;
-	color:#888;
+	color:#575757;
 	font-size:0.75em;
 	margin-bottom:0;
 }
 
 .footnote a {
-	color: #888;
+	color: #575757;
 }
 
 .footnote a:hover{
@@ -119,7 +119,7 @@ a {
 }
 
 .footer-content a {
-	color: #bbb;
+	color: #575757;
 }
 
 .footer-content ul {


### PR DESCRIPTION
Hi @aos! Thanks for the theme, it's quite nice. I noticed that the theme falls short of 100% accessibility due to the low contrast of the footnote and footer elements. This PR darkens the color of these grey elements to `#575757`, the maximum lightness that still achieves the desired contrast ratio of 7. You can take a look at [this online contrast checker](https://webaim.org/resources/contrastchecker/) to try for yourself (the page's background is `#FCFCFC`). 

The PR also removes the need for `!important` on `.footnote a` by changing `.posts li a` to `.posts li > a` to avoid unwanted side effects.