### PR TITLE
Use global `hugo` function instead of `.Hugo`

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -57,7 +57,7 @@
   <link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }} Feed" />
   {{ end }}
 
-  {{ .Hugo.Generator }}
+  {{ hugo.Generator }}
 
   <!-- User custom head -->
   {{ partial "custom_head.html" . }}


### PR DESCRIPTION
To suppress the following warning message, use `hugo` instead of `.Hugo`.

```
$ hugo version
Hugo Static Site Generator v0.57.2-A849CB2D linux/amd64 BuildDate: 2019-08-17T17:54:13Z

$ hugo 
...
WARN 2019/09/02 22:36:47 Page's .Hugo is deprecated and will be removed in a future release. Use the global hugo function.
```
cf. https://gohugo.io/variables/hugo/