### PR TITLE
Add dark mode settings

### DIFF
--- a/layouts/partials/css/custom.css
+++ b/layouts/partials/css/custom.css
@@ -1,14 +1,31 @@
-:root {
-  --color: #484848;
-  --color-footnote: #575757;
-  --color-footer-content: #bbb;
-  --background-color: rgb(252, 252, 252);
-  --background-color-code: rgb(240, 240, 240);
-  --background-color-toggle-content: rgb(249, 249, 249);
-  --link-color: #c05b4d;
-  --link-color-hover: #a5473a;
-  --list-link-color: #369;
-  --border-navbar-and-footer: #e3e3e3;
+@media (prefers-color-scheme: light), (prefers-color-scheme: no-preference) {
+  :root {
+    --color: #484848;
+    --color-footnote: #575757;
+    --color-footer-content: #bbb;
+    --background-color: rgb(252, 252, 252);
+    --background-color-code: rgb(240, 240, 240);
+    --background-color-toggle-content: rgb(249, 249, 249);
+    --link-color: #c05b4d;
+    --link-color-hover: #a5473a;
+    --list-link-color: #369;
+    --border-navbar-and-footer: #e3e3e3;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color: rgb(200, 200, 200);
+    --color-footnote: rgb(150, 150, 150);
+    --color-footer-content: #bbb;
+    --background-color: rgb(5, 5, 5);
+    --background-color-code: rgb(30, 30, 30);
+    --background-color-toggle-content: rgb(10, 10, 10);
+    --link-color: rgb(0, 210, 238);
+    --link-color-hover: rgb(0, 141, 160);
+    --list-link-color: rgb(72, 134, 197);
+    --border-navbar-and-footer: #e3e3e3;
+  }
 }
 
 html {


### PR DESCRIPTION
Apply the color setting of https://github.com/aos/temple/issues/16#issuecomment-527947456.

>But I'm OK with keeping the pre/code, any code blocks and any other code as is without going into dark mode.

Should we remove the block for `code, kbd, pre, samp` (line 48-51)?