### PR TITLE
correct top menu and fix deprecated .RSSLink

### DIFF
--- a/layouts/partials/css/custom-base.css
+++ b/layouts/partials/css/custom-base.css
@@ -249,7 +249,7 @@ kbd, pre, code, samp {
 
 .post-title {
   margin-top: 0;
-  margin-bottom: 2em;
+  margin-bottom: 1em;
 }
 
 .post-title h1 {

--- a/layouts/partials/css/custom-base.css
+++ b/layouts/partials/css/custom-base.css
@@ -15,7 +15,7 @@ a {
   text-decoration: none;
 }
 
-kbd, pre, samp {
+kbd, pre, code, samp {
   background-color: rgb(240, 240, 240);
   background-color: var(--background-color-code);
 }

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -34,8 +34,8 @@
 
         </ul>
         <a href="#" class="pure-menu-link pull-right" id="gototop-btn">↑↑</a>
-        {{ if .RSSLink }}
-        <a href="{{ .RSSLink }}" class="pure-menu-link pull-right">RSS</a>
+        {{ with .OutputFormats.Get "RSS" }}
+        <a href="{{ .RelPermalink }}" class="pure-menu-link pull-right">RSS</a>
         {{ end }}
       </div>
       {{ if .Site.Copyright }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -61,8 +61,8 @@
   type="image/x-icon">
 
   <!-- RSS Feed -->
-  {{ if .RSSLink }}
-  <link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }} Feed" />
+  {{ with .OutputFormats.Get "RSS" }}
+  <link href="{{ .RelPermalink }}" rel="alternate" type="application/rss+xml" title="{{ $.Site.Title | safeHTML }} Feed" />
   {{ end }}
 
   <!-- User custom head -->

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -8,7 +8,7 @@
 				{{ if eq .Site.Params.topmenu "categories" }}
                 {{ range $name,$page := .Site.Taxonomies.categories }}
                 <li class="pure-menu-item">
-                    <a href="{{ $baseurl }}categories/{{ $name | urlize }}" class="pure-menu-link">{{ $name | title }}</a>
+                    <a href="{{ $page.Page.Permalink }}" class="pure-menu-link">{{ $page.Page.Title }}</a>
                 </li>
                 {{ end }}
 				{{ end }}
@@ -25,7 +25,7 @@
 				{{ if eq .Site.Params.topmenu "categories" }}
                 {{ range $name,$page := .Site.Taxonomies.categories }}
                 <li class="pure-menu-item">
-                    <a href="{{ $baseurl }}categories/{{ $name | urlize }}" class="pure-menu-link">{{ $name | title }}</a>
+                    <a href="{{ $page.Page.Permalink }}" class="pure-menu-link">{{ $page.Page.Title }}</a>
                 </li>
                 {{ end }}
 				{{ end }}


### PR DESCRIPTION
For example, originally top menu showed "Operatingsystem",  now it shows "OperatingSystem".