### PR TITLE
Fix deprecation of .Site.Author

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ pygmentsCodeFences = true
   tag = "tags"
   category = "categories"
 
-[author]
+[params.author]
   name = "Aos Dabbagh"
   github = "aos"
   email = "your@email.com"

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -20,7 +20,7 @@ pygmentsCodeFences = true
   tag = "tags"
   category = "categories"
 
-[author]
+[params.author]
   name = "Temple Theme"
   github = "github"
   email = "your@email.com"

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -4,31 +4,31 @@
     <div class="footer-content">
       <div class="pure-menu pure-menu-horizontal">
         <ul>
-          {{ if .Site.Author.name }}
-          <li class="pure-menu-item" id="foot-name">© {{ .Site.Author.name }}</li>
+          {{ if .Site.Params.Author.name }}
+          <li class="pure-menu-item" id="foot-name">© {{ .Site.Params.Author.name }}</li>
           {{ end }}
 
-          {{ if .Site.Author.email }}
+          {{ if .Site.Params.Author.email }}
           <li class="pure-menu-item">
-            <a href="mailto:{{ .Site.Author.email }}" class="pure-menu-link">Email</a>
+            <a href="mailto:{{ .Site.Params.Author.email }}" class="pure-menu-link">Email</a>
           </li>
           {{ end }}
 
-          {{ if .Site.Author.github }}
+          {{ if .Site.Params.Author.github }}
           <li class="pure-menu-item">
-            <a href="https://github.com/{{ .Site.Author.github }}" class="pure-menu-link">GitHub</a>
+            <a href="https://github.com/{{ .Site.Params.Author.github }}" class="pure-menu-link">GitHub</a>
           </li>
           {{ end }}
 
-          {{ if .Site.Author.twitter }}
+          {{ if .Site.Params.Author.twitter }}
           <li class="pure-menu-item">
-            <a href="https://twitter.com/{{ .Site.Author.twitter }}" class="pure-menu-link">Twitter</a>
+            <a href="https://twitter.com/{{ .Site.Params.Author.twitter }}" class="pure-menu-link">Twitter</a>
           </li>
           {{ end }}
 
-          {{ if .Site.Author.medium }}
+          {{ if .Site.Params.Author.medium }}
           <li class="pure-menu-item">
-            <a href="https://medium.com/@{{ .Site.Author.medium }}" class="pure-menu-link">Medium</a>
+            <a href="https://medium.com/@{{ .Site.Params.Author.medium }}" class="pure-menu-link">Medium</a>
           </li>
           {{ end }}
 
@@ -61,13 +61,13 @@
 <script type="text/javascript">
   var a=document.querySelector("#toggle-btn"),b=document.querySelector("#toggle-content");a.addEventListener("click",function(){""==b.style.display?(b.style.display="none",a.innerHTML="☰"):(b.style.display="",a.innerHTML="X")});</script>
 <!-- Google analytics -->
-{{ if .Site.Author.gaid }}
+{{ if .Site.Params.Author.gaid }}
 <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
       m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
   })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-  ga('create', '{{ .Site.Author.gaid }}', 'auto');
+  ga('create', '{{ .Site.Params.Author.gaid }}', 'auto');
   ga('send', 'pageview');
 </script>
 {{ end }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -5,7 +5,7 @@
   <meta charset="utf-8">
   <title>{{ .Title }}</title>
   <meta name="description" content="{{ .Title }}">
-  <meta name="author" content="{{ .Site.Author.name }}">
+  <meta name="author" content="{{ .Site.Params.Author.name }}">
   <!-- Mobile Specific Metas ––––––––––––––––––––––––––––––––––––––––––––––-->
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <!-- FONT –––––––––––––––––––––––––––––––––––––––––––––––––– -->


### PR DESCRIPTION
Use .Site.Params.Author instead.

This fixed building failure:

```
$ hugo
Start building sites … 
hugo v0.136.0 linux/amd64 BuildDate=unknown
ERROR deprecated: .Site.Author was deprecated in Hugo v0.124.0 and will be removed in Hugo 0.137.0. Implement taxonomy 'author' or use .Site.Params.Author instead.
```